### PR TITLE
fix a bug for return false

### DIFF
--- a/lib/vine.rb
+++ b/lib/vine.rb
@@ -19,7 +19,7 @@ class Hash
       else
         ret = ret[p.to_s] || ret[p.to_sym]
       end
-      break unless ret
+      break if ret == nil
     end
     ret
   end

--- a/lib/vine.rb
+++ b/lib/vine.rb
@@ -17,7 +17,13 @@ class Hash
       if p.to_i.to_s == p
         ret = ret[p.to_i]
       else
-        ret = ret[p.to_s] || ret[p.to_sym]
+        if ret[p.to_s] != nil
+          ret = ret[p.to_s]
+        elsif ret[p.to_s] != nil
+          ret = ret[p.to_sym]
+        else
+          ret = nil
+        end
       end
       break if ret == nil
     end


### PR DESCRIPTION
example {'availableForPickup': false}.access('availableForPickup') will return nil not false,
problem, 
vine.rb line 20, ret = ret[p.to_s] || ret[p.to_sym] ret[p.to_s] is false, so it will return ret[p.to_sym] which is nil.

My PR is to fix this problem
