### PR TITLE
Option added to update Hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vine
 
-This gem let you access nested Hash and List structures straightforwardly. 
+This gem let you access and update nested Hash and List structures straightforwardly. 
 
 ### Example
 
@@ -12,8 +12,20 @@ This gem let you access nested Hash and List structures straightforwardly.
     
     {'availableForPickup': false}.access(:availableForPickup)
     => false
-    
+
 ### Example 2
+
+    h = { a: { "b"=> 10 } }
+    h.set("a.b", 2)
+    => { a: { "b"=> 2 } }
+
+    h.set("a.b1.0", 10)
+    => { a: { "b"=> 2, b1: [10] } }
+
+    h.set("a.b.c", 100)
+    => { a: { "b"=> {c: 100}, b1: [10] } }
+
+### Example 3
 
 There is also a method for segmentation.
 

--- a/lib/vine.rb
+++ b/lib/vine.rb
@@ -26,6 +26,34 @@ class Hash
     value
   end
 
+  def set(path, value)
+    keys = []
+    path = path.to_s.split('.')
+
+    [*path, nil].each_cons(2) do |key,nextkey|
+      tmp_hash = keys.inject(self, :fetch)
+
+      if key.to_i.to_s == key
+        key = key.to_i
+      elsif tmp_hash[key].nil?
+        key = key.to_sym
+      end
+
+      if tmp_hash[key].nil?
+        tmp_hash[key] = {}
+      elsif nextkey.to_i.to_s == nextkey && !tmp_hash[key].is_a?(Array)
+        tmp_hash[key] = []
+      elsif !nextkey.nil? && !tmp_hash[key].is_a?(Hash)
+        tmp_hash[key] = {}
+      end
+
+      keys << key
+    end # each_cons
+
+    last_key = keys.pop
+    keys.inject(self, :fetch)[last_key] = value
+  end
+
   alias :vine :access
 
 end

--- a/test/test_vine.rb
+++ b/test/test_vine.rb
@@ -1,7 +1,7 @@
 require_relative "../lib/vine"
 require "minitest/autorun"
 
-class TestMeme < MiniTest::Unit::TestCase
+class TestMeme < MiniTest::Test
 
   def test_access
     assert_equal 100,   { a: [ 100, 200 ] }.access("a.0")

--- a/test/test_vine.rb
+++ b/test/test_vine.rb
@@ -12,4 +12,21 @@ class TestMeme < MiniTest::Unit::TestCase
     assert_equal false, { 'key' => false }.access("key")
   end
   
+  def test_set
+    h = { a: { "b"=> 10 } }
+    h.set("a.b", 2)
+    assert_equal 2,     h[:a]["b"]
+
+    h.set("a.b1.0", 10)
+    assert_equal 10,    h[:a][:b1][0]
+
+    h.set("a.b.c", 100)
+    assert_equal 100,   h[:a]["b"][:c]
+
+    h.set("a.b.c.1.f.0", 1)
+    assert_equal 1,     h[:a]["b"][:c][1][:f][0]
+
+    h.set("a.e.c.1.f.2", 10)
+    assert_equal 10,    h[:a][:e][:c][1][:f][2]
+  end
 end


### PR DESCRIPTION
This is very useful gem for me, but I needed update the hash object too, with the same notation.

So I added a new _set_ method to Hash class, that receive a path and value to update, for example:

```
h = { a: { "b"=> 10 } }
h.set("a.b", 2)
=> { a: { "b"=> 2 } }

h.set("a.b1.0", 10)
=> { a: { "b"=> 2, b1: [10] } }

h.set("a.b.c", 100)
=> { a: { "b"=> {c: 100}, b1: [10] } }
```

I added tests to test_vine.rb and updated README too.

I hope this is useful for this gem and you seem good to integrate this code.
